### PR TITLE
Add Ollama tweet chat demo with context and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,33 @@ Run unit tests with:
 ```bash
 pytest
 ```
+
+
+## Traubleshooting
+
+### Installing Ollama
+Steps to run Ollama with llama2 in a GitHub Codespace
+
+1. Install Ollama
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+2. Start the server (background)
+
+```bash
+ollama serve &
+```
+3. Download the model
+
+```bash
+ollama pull llama2
+```
+4. Verify
+
+```bash
+ollama run llama2 "Hello!"
+```
+5. Expose port 11434
+Forward it in your Codespace so your app can reach the server.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# AI-chat
+# AI Chat with Ollama
+
+This project demonstrates a conversational chatbot powered by [Ollama](https://ollama.com/).
+Responses are tweet-sized (maximum 180 characters) and respect word boundaries.
+
+## Features
+- Maintains context for the last three interactions
+- Ensures replies are in English with correct grammar
+- Truncates answers to 180 characters without cutting words
+- Command line interface with visible conversation history
+
+## Requirements
+- Python 3.10+
+- A running [Ollama](https://ollama.com/) server with a suitable model (e.g., `llama2`)
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Start the chat:
+
+```bash
+python main.py
+```
+Type messages and the bot will answer in tweet format. Use `exit` to quit; the
+full conversation history will then be displayed.
+
+## Testing
+Run unit tests with:
+
+```bash
+pytest
+```

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,50 @@
+"""Chatbot using Ollama to generate concise English responses."""
+from typing import List, Dict
+
+try:
+    import ollama  # type: ignore
+except Exception:  # pragma: no cover - library may not be installed
+    class _OllamaFallback:
+        """Fallback that raises if Ollama is unavailable."""
+        def chat(self, *args, **kwargs):
+            raise RuntimeError("Ollama library is required to run this chatbot.")
+    ollama = _OllamaFallback()
+
+from utils import truncate_tweet, MAX_TWEET_LEN
+
+class Chatbot:
+    """A simple conversational agent that maintains short context."""
+
+    def __init__(self, model: str = "llama2") -> None:
+        self.model = model
+        self.history: List[Dict[str, str]] = []
+
+    def _build_messages(self, user_input: str) -> List[Dict[str, str]]:
+        """Prepare messages with system prompt and limited context."""
+        system = {
+            "role": "system",
+            "content": (
+                "You are a friendly AI that replies in English with correct "
+                f"grammar. Keep answers under {MAX_TWEET_LEN} characters."
+            ),
+        }
+        context = self.history[-6:]  # last 3 interactions (user+assistant)
+        messages = [system] + context + [{"role": "user", "content": user_input}]
+        return messages
+
+    def generate(self, user_input: str) -> str:
+        """Generate a response and update history."""
+        messages = self._build_messages(user_input)
+        response = ollama.chat(model=self.model, messages=messages)
+        text = response["message"]["content"].strip()
+        text = truncate_tweet(text)
+        self.history.extend(
+            [{"role": "user", "content": user_input}, {"role": "assistant", "content": text}]
+        )
+        return text
+
+    def display_history(self) -> None:
+        """Print the conversation history."""
+        for msg in self.history:
+            prefix = "User" if msg["role"] == "user" else "Bot"
+            print(f"{prefix}: {msg['content']}")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+"""Simple command line chat using Ollama."""
+from chatbot import Chatbot
+
+
+def main() -> None:
+    bot = Chatbot()
+    print("Type your message (or 'exit' to quit):")
+    while True:
+        try:
+            user_input = input("You: ")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        try:
+            reply = bot.generate(user_input)
+        except Exception as exc:  # pragma: no cover - depends on environment
+            print(f"Error: {exc}")
+            break
+        print(f"Bot: {reply}")
+    print("\nConversation history:")
+    bot.display_history()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ollama
+pytest

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,22 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from chatbot import Chatbot, ollama
+
+
+def test_context_keeps_last_three_interactions(monkeypatch):
+    captured = {}
+
+    def fake_chat(model, messages):
+        captured['messages'] = messages
+        return {'message': {'content': 'ok'}}
+
+    monkeypatch.setattr(ollama, 'chat', fake_chat)
+    bot = Chatbot(model='test')
+    for i in range(5):
+        bot.generate(f'msg{i}')
+    assert len(bot.history) == 10
+    assert len(captured['messages']) == 8  # system + 3 interactions *2 + new user
+    assert captured['messages'][1]['content'] == 'msg1'
+    assert captured['messages'][-1]['content'] == 'msg4'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import truncate_tweet
+
+
+def test_no_truncation_when_short():
+    text = "Hello world"
+    assert truncate_tweet(text, limit=50) == text
+
+
+def test_truncation_respects_word_boundary():
+    text = "hello world this is a test"
+    assert truncate_tweet(text, limit=17) == "hello world this"
+
+
+def test_truncation_without_spaces():
+    text = "a" * 200
+    result = truncate_tweet(text, limit=50)
+    assert len(result) <= 50

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,19 @@
+"""Utility helpers for tweet-sized responses."""
+from __future__ import annotations
+
+MAX_TWEET_LEN = 180
+
+
+def truncate_tweet(text: str, limit: int = MAX_TWEET_LEN) -> str:
+    """Truncate text at a word boundary without exceeding the limit."""
+    if len(text) <= limit:
+        return text
+    truncated = text[:limit]
+    cut_index = -1
+    for ch in [" ", ",", ".", "?", "!", ";", ":"]:
+        idx = truncated.rfind(ch)
+        if idx > cut_index:
+            cut_index = idx
+    if cut_index == -1:
+        return truncated.rstrip()
+    return truncated[:cut_index].rstrip()


### PR DESCRIPTION
## Summary
- create Chatbot class wrapping Ollama with 180-character English replies
- add CLI entrypoint and utilities for truncating on word boundaries
- document setup and provide tests for tweet truncation and context memory

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bba7688cf883319712439a6592267a